### PR TITLE
Fix for https://github.com/aerorahul/mom6-tools/issues/1

### DIFF
--- a/scripts/ufs/gfs_forcings.py
+++ b/scripts/ufs/gfs_forcings.py
@@ -132,10 +132,10 @@ if __name__ == '__main__':
 
     # Collect precipitation rates from prate_ave
     coeff = get_coeff(dsfcf000['tmp2m'], threshold=-15.)
-    dforcing['precp'] = coeff * dsfcf006['prate_ave']
+    dforcing['precp'] = coeff * dsfcf006['prate_ave'].squeeze()
     dforcing['precp'].attrs = dsfcf006['prate_ave'].attrs
     dforcing['precp'].attrs['long_name'] = 'surface rain precipitation rate'
-    dforcing['fprecp'] = (1.0 - coeff) * dsfcf006['prate_ave']
+    dforcing['fprecp'] = (1.0 - coeff) * dsfcf006['prate_ave'].squeeze()
     dforcing['fprecp'].attrs = dsfcf006['prate_ave'].attrs
     dforcing['fprecp'].attrs['long_name'] = 'surface snow precipitation rate'
 


### PR DESCRIPTION
This PR fixes https://github.com/aerorahul/mom6-tools/issues/1

Run same way:
```
./gfs_forcings.py --sfcf000 /scratch2/NCEPDEV/marine/Santha.Akella/data/GFS/gdas.20241130/00/atmos/gdas.t00z.sfcf000.nc --sfcf006 /scratch2/NCEPDEV/marine/Santha.Akella/data/GFS/gdas.20241130/00/atmos/gdas.t00z.sfcf006.nc 
```

STDOUT:
```
2025-02-08 01:08:08,559 - INFO     - forcing : starting ...
2025-02-08 01:08:08,576 - INFO     - forcing : reading file: /scratch2/NCEPDEV/marine/Santha.Akella/data/GFS/gdas.20241130/00/atmos/gdas.t00z.sfcf000.nc
/scratch2/NCEPDEV/marineda/Santha.Akella/envs/py31013/lib/python3.10/site-packages/numpy/core/getlimits.py:518: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  setattr(self, word, getattr(machar, word).flat[0])
/scratch2/NCEPDEV/marineda/Santha.Akella/envs/py31013/lib/python3.10/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.
  return self._float_to_str(self.smallest_subnormal)
2025-02-08 01:08:17,947 - INFO     - forcing : reading file: /scratch2/NCEPDEV/marine/Santha.Akella/data/GFS/gdas.20241130/00/atmos/gdas.t00z.sfcf006.nc
2025-02-08 01:10:23,318 - INFO     - forcing : writing file: forcing.nc
2025-02-08 01:11:46,027 - INFO     - forcing : done!
```

Additionally:
```
(py31013) [Santha.Akella@hfe02 ufs]$ ls -al forcing.nc 
-rw-r--r-- 1 Santha.Akella marine 546775812 Feb  8 01:11 forcing.nc
(py31013) [Santha.Akella@hfe02 ufs]$ 
(py31013) [Santha.Akella@hfe02 ufs]$ ncdump -h forcing.nc 
netcdf forcing {
dimensions:
        grid_xt = 3072 ;
        grid_yt = 1536 ;
        time = 2 ;
variables:
        double grid_xt(grid_xt) ;
...
...
...
```